### PR TITLE
Make server IP address a program argument on client side

### DIFF
--- a/Multiple_Clients/client.py
+++ b/Multiple_Clients/client.py
@@ -5,12 +5,12 @@ import time
 import signal
 import sys
 import struct
+import argparse
 
 class Client(object):
 
-    def __init__(self):
-        # self.serverHost = '192.168.1.9'
-        self.serverHost = '192.168.0.5'
+    def __init__(self, host):
+        self.serverHost = host
         self.serverPort = 9999
         self.socket = None
 
@@ -104,26 +104,24 @@ class Client(object):
         return
 
 
-def main():
-    client = Client()
-    client.register_signal_handler()
-    client.socket_create()
-    while True:
-        try:
-            client.socket_connect()
-        except Exception as e:
-            print("Error on socket connections: %s" %str(e))
-            time.sleep(5)     
-        else:
-            break    
-    try:
-        client.receive_commands()
-    except Exception as e:
-        print('Error in main: ' + str(e))
-    client.socket.close()
-    return
-
-
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--host', type=str, default='192.168.0.5', help="Default host IP address")
+    args = parser.parse_args()
     while True:
-        main()
+        client = Client(args.host)
+        client.register_signal_handler()
+        client.socket_create()
+        while True:
+            try:
+                client.socket_connect()
+            except Exception as e:
+                print("Error on socket connections: %s" %str(e))
+                time.sleep(5)
+            else:
+                break
+        try:
+            client.receive_commands()
+        except Exception as e:
+            print('Error in main: ' + str(e))
+        client.socket.close()

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ To select a target from the list of clients:
 
 ## Client
 
-In **client.py**, first change the IP address to that of the server and then run on target machine. If client does not have a compatible version of Python installed, you can create an executable by building from the source using **setup.py**.
+Run **client.py** with the host IP address as a program argument. For example:
+``` sh
+python3 client.py --host=192.168.0.5
+```
+
+If client does not have a compatible version of Python installed, you can create an executable by building from the source using **setup.py**.
 
 `python setup.py build`

--- a/Single_Client/client.py
+++ b/Single_Client/client.py
@@ -1,7 +1,7 @@
 import os
 import socket
 import subprocess
-
+import argparse
 
 # Create a socket
 def socket_create():
@@ -9,7 +9,6 @@ def socket_create():
         global host
         global port
         global s
-        host = '192.168.0.5'
         port = 9999
         s = socket.socket()
     except socket.error as msg:
@@ -43,10 +42,11 @@ def receive_commands():
     s.close()
 
 
-def main():
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--host', type=str, default='192.168.0.5', help="Default host IP address")
+    args = parser.parse_args()
+    host = args.host
     socket_create()
     socket_connect()
     receive_commands()
-
-
-main()


### PR DESCRIPTION
Server host IP can now be specified as a program argument as follows:
``` sh
python3 client.py --host=192.168.0.5
```